### PR TITLE
feat: [KAN-125] hobom event processor kafka publish

### DIFF
--- a/infra/kafka/publisher/publisher.go
+++ b/infra/kafka/publisher/publisher.go
@@ -2,8 +2,8 @@ package publisher
 
 import (
 	"context"
+	"fmt"
 
-	utils "github.com/HoBom-s/hobom-event-processor/pkg/utils"
 	"github.com/segmentio/kafka-go"
 )
 
@@ -28,6 +28,7 @@ func NewKafkaPublisher(cfg KafkaConfig, hooks ...Hook) KafkaPublisher {
 			RequiredAcks: cfg.Acks,
 		},
 	}
+	fmt.Println("🎃 Kafka connected")
 
 	return &kafkaPublisher{
 		cfg:    cfg,
@@ -41,17 +42,12 @@ func (p *kafkaPublisher) Publish(ctx context.Context, event Event) error {
 		hook.BeforePublish(ctx, event)
 	}
 
-	topic := event.Topic
-	if utils.IsEmptyString(topic) {
-		topic = p.cfg.DefaultTopic
-	}
 
 	msg := kafka.Message{
 		Key:       []byte(event.Key),
 		Value:     event.Value,
 		Headers:   event.Headers,
 		Time:      event.Timestamp,
-		Topic:     topic,
 	}
 
 	err := p.writer.WriteMessages(ctx, msg)

--- a/internal/poller/const.go
+++ b/internal/poller/const.go
@@ -1,11 +1,18 @@
 package poller
 
 const (
-  // Define Kafka Event Type
+  // Define Kafka Event Types
   EventTypeTodayMenu 	= "TODAY_MENU"
 
-  // Outbox Status
+  // Outbox Statuss
   OutboxPending 		= "PENDING"
   OutboxSent    		= "SENT"
   OutboxFailed			= "FAILED"
+
+  // Kafka Topics
+  HoBomMessage     = "hobom.messages"
+
+  // Message Types
+  Mail            = "MAIL_MESSAGE"
+  Push            = "PUSH_MESSAGE"
 )

--- a/internal/poller/message.go
+++ b/internal/poller/message.go
@@ -1,0 +1,12 @@
+package poller
+
+import "time"
+
+type DeliverHoBomMessageCommand struct {
+	Type      string    `json:"type"`
+	Title     string    `json:"title"`
+	Body      string    `json:"body"`
+	Recipient string    `json:"recipient"`
+	SenderId  *string   `json:"senderId,omitempty"` // nullable
+	SentAt    time.Time `json:"sentAt"`
+}

--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sync"
 
+	publisher "github.com/HoBom-s/hobom-event-processor/infra/kafka/publisher"
 	"google.golang.org/grpc"
 )
 
@@ -15,11 +16,12 @@ type Poller interface {
 
 // 모든 polling 을 초기화 및 수행하도록 한다.
 // gRPC 통신을 위한 초기 로직을 수행하도록 한다.
-func StartAllPollers(ctx context.Context, conn *grpc.ClientConn) {
+// Kafka도 파라미터로 의존성을 주입받아 Event Publishing을 수행하도록 한다.
+func StartAllPollers(ctx context.Context, conn *grpc.ClientConn, kafkaPublisher publisher.KafkaPublisher) {
 	var wg sync.WaitGroup
 
 	pollers := []Poller{
-		NewTodayMenuPoller(conn),
+		NewTodayMenuPoller(conn, kafkaPublisher),
 	}
 
 	for _, p := range pollers {


### PR DESCRIPTION
## 🚀 Summary

hobom-event-processor kafka publish.

### flow
1. gRPC Polling
2. Kafka event publish
3. gRPC Patch request


- 목적: 기능 추가

---

## 📸 Screenshots / API Contract (옵션)

-

---

## 🚦 Deployment & Rollback Plan

- DB 마이그레이션 필요: (Y/N)
- 환경 변수 추가/변경: (Y/N)
- 롤백 전략: 트랜잭션 기반 롤백 / DB snapshot 복구 등

---

## 🙋 Reviewer Notes

- (예: 트랜잭션 처리 부분 검토 부탁드립니다.)
- (예: 이벤트 발행 위치에 대해 의견 요청드립니다.)
