### PR TITLE
feat: [KAN-140] hobom-event-processor DLQ 수동 발행 및 목록 Internal API

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,7 +56,7 @@ func main() {
 	// 5-1. DLQ Router
 	router := gin.Default()
 	health.RegisterRoutes(router)
-	dlq.RegisterRoutes(router, rc, kafkaPublisher)
+	dlq.RegisterRoutes(router, rc, kafkaPublisher, conn)
 	server := &http.Server{
 		Addr:    ":8081",
 		Handler: router,

--- a/internal/dlq/handler.go
+++ b/internal/dlq/handler.go
@@ -1,0 +1,69 @@
+package dlq
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type DLQHandler struct {
+	Service *DLQService
+}
+
+func NewHandler(service *DLQService) *DLQHandler {
+	return &DLQHandler{
+		Service: service,
+	}
+}
+
+// `GET` /dlq
+// Redis에 저장된 DLQ 키 목록을 가져온다.
+// prefix가 빈 문자열("") 이라면 모든 DLQ를 조회하도록 한다.
+// ex) ?prefix=dlq:menu: 또는 ?prefix=dlq:log:
+func (h *DLQHandler) GetDLQS(c *gin.Context) {
+	prefix := c.Query("prefix")
+
+	keys, err := h.Service.GetDLQS(c.Request.Context(), prefix)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to fetch DLQ keys: %v", err)})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"items": keys})
+}
+
+// `GET` /dlq/:key
+// Key값에 해당하는 DLQ를 가져오도록 한다.
+func (h *DLQHandler) GetDLQ(c *gin.Context) {
+	key := c.Param("key")
+
+	data, err := h.Service.GetDLQValue(context.Background(), key)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("DLQ not found: %v", err)})
+		return
+	}
+
+	var pretty map[string]interface{}
+	if err := json.Unmarshal(data, &pretty); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse DLQ JSON"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"item": pretty})
+}
+
+// `POST` /dlq/retry/:key
+// DLQ를 재발행 하도록 한다.
+func (h *DLQHandler) RetryDLQ(c *gin.Context) {
+	key := c.Param("key")
+
+	if err := h.Service.RetryDLQ(c.Request.Context(), key); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "DLQ retried and removed from Redis"})
+}

--- a/internal/dlq/helpers.go
+++ b/internal/dlq/helpers.go
@@ -1,0 +1,22 @@
+package dlq
+
+import (
+	poller "github.com/HoBom-s/hobom-event-processor/internal/poller"
+)
+
+func inferTopicFromKey(key string) string {
+	switch {
+	case hasPrefix(key, poller.HoBomTodayMenuDLQPrefix):
+		return poller.HoBomMessage
+
+	case hasPrefix(key, poller.HoBomLogDLQPrefix):
+		return poller.HoBomLog
+		
+	default:
+		return "unknown-topic"
+	}
+}
+
+func hasPrefix(s string, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/internal/dlq/helpers.go
+++ b/internal/dlq/helpers.go
@@ -1,9 +1,13 @@
 package dlq
 
 import (
+	"strings"
+
 	poller "github.com/HoBom-s/hobom-event-processor/internal/poller"
 )
 
+// DLQ Key를 통해, Kafka Topic을 추출하도록 한다.
+// 올바른 Key가 맵핑되지 않을 경우, `unknown-topic`을 반환하도록 한다.
 func inferTopicFromKey(key string) string {
 	switch {
 	case hasPrefix(key, poller.HoBomTodayMenuDLQPrefix):
@@ -17,6 +21,15 @@ func inferTopicFromKey(key string) string {
 	}
 }
 
+// Prefix에 해당하는지 검증하도록 한다.
 func hasPrefix(s string, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// 전달받은 Parameter에서 `:` 기준으로 문자열을 자른 후, `EventID`를 추출하도록 한다.
+// Redis에 저장되는 DLQ Key의 경우 `dlq:[category]:event-id`와 같은 규칙을 따르고 있으므로,
+// `:` 로 분류된 맨 마지막 문자열이 `EventID` 이다.
+func extractEventIdFromKey(key string) string {
+	parts := strings.Split(key, ":")
+	return parts[len(parts)-1]
 }

--- a/internal/dlq/route.go
+++ b/internal/dlq/route.go
@@ -1,14 +1,16 @@
 package dlq
 
 import (
+	outboxPb "github.com/HoBom-s/hobom-event-processor/infra/grpc/menu/outbox/v1"
 	"github.com/HoBom-s/hobom-event-processor/infra/kafka/publisher"
 	"github.com/HoBom-s/hobom-event-processor/infra/redis"
 	poller "github.com/HoBom-s/hobom-event-processor/internal/poller"
 	"github.com/gin-gonic/gin"
+	"google.golang.org/grpc"
 )
 
-func RegisterRoutes(router *gin.Engine, redisDLQ *redis.RedisDLQStore, pub publisher.KafkaPublisher) {
-	service := NewService(redisDLQ, pub)
+func RegisterRoutes(router *gin.Engine, redisDLQ *redis.RedisDLQStore, pub publisher.KafkaPublisher, conn *grpc.ClientConn) {
+	service := NewService(redisDLQ, pub, outboxPb.NewPatchOutboxControllerClient(conn))
 	handler := NewHandler(service)
 
 	dlq := router.Group(poller.HoBomEventPrcessorInternalApiPrefix + "/dlq")

--- a/internal/dlq/route.go
+++ b/internal/dlq/route.go
@@ -1,0 +1,20 @@
+package dlq
+
+import (
+	"github.com/HoBom-s/hobom-event-processor/infra/kafka/publisher"
+	"github.com/HoBom-s/hobom-event-processor/infra/redis"
+	poller "github.com/HoBom-s/hobom-event-processor/internal/poller"
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterRoutes(router *gin.Engine, redisDLQ *redis.RedisDLQStore, pub publisher.KafkaPublisher) {
+	service := NewService(redisDLQ, pub)
+	handler := NewHandler(service)
+
+	dlq := router.Group(poller.HoBomEventPrcessorInternalApiPrefix + "/dlq")
+	{
+		dlq.GET("", handler.GetDLQS)
+		dlq.GET("/:key", handler.GetDLQ)
+		dlq.POST("/retry/:key", handler.RetryDLQ)
+	}
+}

--- a/internal/dlq/service.go
+++ b/internal/dlq/service.go
@@ -1,0 +1,76 @@
+package dlq
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/HoBom-s/hobom-event-processor/infra/kafka/publisher"
+	"github.com/HoBom-s/hobom-event-processor/infra/redis"
+	"github.com/HoBom-s/hobom-event-processor/pkg/utils"
+)
+
+type DLQService struct {
+	RedisDLQ  *redis.RedisDLQStore
+	Publisher publisher.KafkaPublisher
+}
+
+// DLQ Service를 초기화 하도록 한다.
+func NewService(redis *redis.RedisDLQStore, pub publisher.KafkaPublisher) *DLQService {
+	return &DLQService{
+		RedisDLQ:  redis,
+		Publisher: pub,
+	}
+}
+
+// DLQ 저장소에서 DLQ Key 목록을 조회한다.
+// 기본적으로 모든 DLQ(key: dlq:*)를 조회하며, 선택적으로 `prefix` 필터링도 가능하다.
+func (s * DLQService) GetDLQS(ctx context.Context, prefix string) ([]string, error) {
+	var dlqPrefix = ""
+	if utils.IsEmptyString(prefix) {
+		dlqPrefix = "dlq:*"
+	} else {
+		dlqPrefix = prefix + "*"
+	}
+
+	keys, err := s.RedisDLQ.List(ctx, dlqPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list DLQ keys: %w", err)
+	}
+	return keys, nil
+}
+
+// DLQ 저장소에서 Key에 해당하는
+// DLQ Payload를 가져오도록 한다.
+// 만약 해당 Key값이 존재하지 않으면 에러를 발생시킨다.
+func (s *DLQService) GetDLQValue(ctx context.Context, key string) ([]byte, error) {
+	return s.RedisDLQ.Get(ctx, key)
+}
+
+// DLQ를 재발행 하도록 한다.
+// DLQ가 없다면 에러가 발생하고, 존재한다면, Event를 재발행 하도록 한다.
+// 이벤트를 재발행 한 후, DLQ를 Redis에서 제거하도록 한다.
+func (s *DLQService) RetryDLQ(ctx context.Context, key string) error {
+	data, err := s.RedisDLQ.Get(ctx, key)
+	if err != nil {
+		return fmt.Errorf("failed to get DLQ: %w", err)
+	}
+
+	// Event를 재발행 하도록 한다.
+	err = s.Publisher.Publish(ctx, publisher.Event{
+		Key:       key,
+		Value:     data,
+		Topic:     inferTopicFromKey(key),
+		Timestamp: time.Now().UTC(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to publish: %w", err)
+	}
+
+	// DLQ를 제거하도록 한다.
+	if err := s.RedisDLQ.Delete(ctx, key); err != nil {
+		fmt.Printf("⚠️ Failed to delete DLQ after retry: %v\n", err)
+	}
+
+	return nil
+}

--- a/internal/poller/const.go
+++ b/internal/poller/const.go
@@ -21,8 +21,13 @@ const (
   Push            = "PUSH_MESSAGE"
 
   // DLQ Keys
+  // DLQ의 Key는 Prefix로 `dlq:`를 가져야 함에 주의하도록 한다.
   HoBomTodayMenuDLQPrefix    = "dlq:menu:"
   HoBomLogDLQPrefix          = "dlq:log:"
 
+  // DLQ TTL
   TTL72Hours                 = 72 * time.Hour
+
+  // Internal API Prefix
+  HoBomEventPrcessorInternalApiPrefix     = "/hobom-event-processor/internal/api/v1"
 )


### PR DESCRIPTION
## 🚀 Summary

- HoBom Event Processor DLQ 수동발행 및 목록 Internal API 추가
- gRPC 는 Polling과 같은, 성능 및 안정적인 통신에서만 사용하기로 결정
  - (low-latency + high-throughput)
- Dead Letter Queue는 단순 Internal UI를 통해 제어할 목적이므로, hobom-internal-backend에서 호출할 Internal API 제공
- DLQ 수동 발행 후, gRPC를 통해 Outbox 데이터 업데이트 수행

- 목적: 기능 추가

---

## 📸 Screenshots / API Contract (옵션)

- 

---

## 🚦 Deployment & Rollback Plan

- DB 마이그레이션 필요: (N)
- 환경 변수 추가/변경: (N)
- 롤백 전략: -

---

## 🙋 Reviewer Notes

- (예: 트랜잭션 처리 부분 검토 부탁드립니다.)
- (예: 이벤트 발행 위치에 대해 의견 요청드립니다.)
