### PR TITLE
fix(angel): tag angel access logs as HOBOM_ANGEL

### DIFF
--- a/internal/poller/angel_log_poller.go
+++ b/internal/poller/angel_log_poller.go
@@ -14,7 +14,8 @@ import (
 )
 
 // angelLogServiceType tags Angel access logs in the shared "hobom.logs" stream.
-const angelLogServiceType = "ANGEL"
+// Must match hobom-internal-backend's ServiceType enum (HOBOM_* convention).
+const angelLogServiceType = "HOBOM_ANGEL"
 
 type angelLogPoller struct {
 	findClient  angelPb.FindHoBomAngelOutboxControllerClient


### PR DESCRIPTION
AngelLogPoller sent `serviceType: "ANGEL"`, but hobom-internal-backend's `ServiceType` enum uses the `HOBOM_*` convention (`HOBOM_SPACE`, `HOBOM_BACKEND`, …). The consumer rejected "ANGEL" → Angel access logs failed to deserialize and never persisted. Now sends `"HOBOM_ANGEL"`.

Paired with adding `HOBOM_ANGEL` to internal-backend's ServiceType enum (separate PR). `go build`/`test` pass.